### PR TITLE
fix validating of combinations

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -55,11 +55,11 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
 
   if (!ignoreModifiers) {
     // We check the pressed keys for compatibility with the keyup event. In keyup events the modifier flags are not set.
-    if (alt === !altKey && (alt && pressedKey !== 'alt')) {
+    if (alt === !altKey && pressedKey !== 'alt') {
       return false
     }
 
-    if (shift === !shiftKey && (shift && pressedKey !== 'shift')) {
+    if (shift === !shiftKey && pressedKey !== 'shift') {
       return false
     }
 
@@ -69,11 +69,11 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
         return false
       }
     } else {
-      if (meta === !metaKey && (meta && pressedKey !== 'meta')) {
+      if (meta === !metaKey && pressedKey !== 'meta') {
         return false
       }
 
-      if (ctrl === !ctrlKey && (ctrl && pressedKey !== 'ctrl')) {
+      if (ctrl === !ctrlKey && pressedKey !== 'ctrl') {
         return false
       }
     }

--- a/tests/useHotkeys.test.tsx
+++ b/tests/useHotkeys.test.tsx
@@ -1088,3 +1088,26 @@ test('Should ignore modifiers if option is set', async () => {
 
   expect(callback).toHaveBeenCalledTimes(2)
 })
+
+test('Should trigger only callback for combination', async () => {
+  const user = userEvent.setup()
+  const combinationsCallback = jest.fn()
+  const keysCallback = jest.fn()
+
+  const handleHotkey = (event, hotkeysEvent) =>{
+      const {meta,keys} = hotkeysEvent
+      if(meta && keys[0] === 'z'){
+        combinationsCallback()
+      }else if(!meta && keys[0] === 'z'){
+        keysCallback()
+      }
+  }
+
+  renderHook(() => useHotkeys([`meta+z`, `z`], handleHotkey))
+
+  await user.keyboard(`{Meta>}Z`)
+
+  expect(combinationsCallback).toHaveBeenCalledTimes(1)
+
+  expect(keysCallback).toHaveBeenCalledTimes(0)
+})


### PR DESCRIPTION
Fixed a bug where clicking "hotkey + smth" triggers an event for "hotkey + smth" and "smth"
